### PR TITLE
Skips Citizenship row

### DIFF
--- a/java/Program.java
+++ b/java/Program.java
@@ -37,7 +37,7 @@ import java.util.*;
         {
             Scanner streamReader = new Scanner(new FileInputStream("WorldWealthList.txt"));
             String record;
-            int size = 2;
+            int size = 3;
             List<Person> data = new ArrayList<Person>();
             while (streamReader.hasNextLine() && size > 0)
             {


### PR DESCRIPTION
Hallo Marco,
bin mir nicht ganz sicher, aber möglicherweise hab ich einen kleinen Bug in der Java-Version Deiner Billionärs-Kata gefunden. 

Wenn Du Dir den Output des Programms anschaust, wirst du sehen, dass in der letzten Zeile
Citizenship 1 ,00
steht. Offenbar wurde hier die Titelzeile mit interpretiert. Gehört es zur Aufgabenstellung diesen Bug zu fixen? Wenn nein, dann mast du vielleicht diesen Pullrequest annehmen.

Dank Dir
Bis dann
Christian